### PR TITLE
set G_SLICE to always-malloc when running insure environment

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -140,6 +140,14 @@ if (! $?OFFLINE_MAIN) then
   setenv OFFLINE_MAIN /afs/rhic.bnl.gov/sphenix/new/../$opt_v/
 endif
 
+if ($OFFLINE_MAIN =~ *"insure"* ) then
+  setenv G_SLICE always-malloc
+else
+  if ($?G_SLICE) then
+    unsetenv G_SLICE
+  endif
+endif
+
 # Normalize OFFLINE_MAIN 
 if (-d $OFFLINE_MAIN) then
   set here=`pwd`

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -155,6 +155,18 @@ then
   fi
   export OFFLINE_MAIN=/afs/rhic.bnl.gov/sphenix/new/../$opt_v/
 fi
+
+if [[ $OFFLINE_MAIN = *insure* ]]
+then
+  export G_SLICE=always-malloc
+else
+  if [ ! -z "$G_SLICE" ]
+  then
+    unset G_SLICE
+  fi
+fi
+
+
 # Normalize OFFLINE_MAIN 
 if [ -d $OFFLINE_MAIN ] 
 then


### PR DESCRIPTION
Running sims under root_insure.exe one gets as soon as the macro is started:
***MEMORY-ERROR***: [29891]: GSlice: assertion failed:
aligned_memory == (gpointer) addr
Abort

setting G_SLICE to always-malloc fixes this. It likely leads to a (small) performance hit, so the setup scripts check if OFFLINE_MAIN points to an insure build to enable this. If it doesn't, the scripts check if G_SLICE is set and if so unset it (in case someone switches the environment back and forth)