### PR TITLE
replace afs path to /opt/sphenix again by direct /opt/sphenix

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -102,14 +102,14 @@ else
 endif
 
 if (! $?OPT_SPHENIX) then
-  if (-d /afs/rhic.bnl.gov/opt/sphenix/core) then
-    setenv OPT_SPHENIX /afs/rhic.bnl.gov/opt/sphenix/core
+  if (-d /opt/sphenix/core) then
+    setenv OPT_SPHENIX /opt/sphenix/core
   endif
 endif
 
 if (! $?OPT_UTILS) then
-  if (-d /afs/rhic.bnl.gov/opt/sphenix/utils) then
-    setenv OPT_UTILS /afs/rhic.bnl.gov/opt/sphenix/utils
+  if (-d /opt/sphenix/utils) then
+    setenv OPT_UTILS /opt/sphenix/utils
   endif
 endif
 

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -103,14 +103,14 @@ else
     unset ORIG_MANPATH
 fi
 
-if [[ -z "$OPT_SPHENIX" && -d /afs/rhic.bnl.gov/opt/sphenix/core ]]
+if [[ -z "$OPT_SPHENIX" && -d /opt/sphenix/core ]]
 then
-  export OPT_SPHENIX=/afs/rhic.bnl.gov/opt/sphenix/core
+  export OPT_SPHENIX=/opt/sphenix/core
 fi
 
-if [[ -z "$OPT_UTILS" && -d /afs/rhic.bnl.gov/opt/sphenix/utils ]]
+if [[ -z "$OPT_UTILS" && -d /opt/sphenix/utils ]]
 then
-    export OPT_UTILS=/afs/rhic.bnl.gov/opt/sphenix/utils
+    export OPT_UTILS=/opt/sphenix/utils
 fi
 
 # set site wide compiler options (no rpath hardcoding)


### PR DESCRIPTION
the previous path in /afs messed with the container. This will be put back in once we switch to cvmfs for the afs version