### PR TITLE
setting of xercesroot to /afs/rhic.bnl.gov/opt/sphenix/core was wrong…

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -131,10 +131,6 @@ if (! $?PERL5LIB) then
    endif
 endif
 
-if (! $?XERCESCROOT) then
-  setenv XERCESCROOT ${OPT_SPHENIX}/geant4
-endif
-
 if (! $?LHAPATH) then
   setenv LHAPATH ${OPT_SPHENIX}/lhapdf-5.9.1/share/lhapdf/PDFsets
 endif
@@ -237,6 +233,9 @@ if (-d $G4_MAIN) then
         endif
     endif
 
+endif
+if (! $?XERCESCROOT) then
+  setenv XERCESCROOT $G4_MAIN
 endif
 
 #Pythia8

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -137,11 +137,6 @@ then
    fi
 fi
 
-if [[ -z "$XERCESCROOT" && -d ${OPT_SPHENIX}/geant4 ]]
-then
-  export XERCESCROOT=${OPT_SPHENIX}/geant4
-fi
-
 if [[ -z "$LHAPATH" && -d ${OPT_SPHENIX}/lhapdf-5.9.1/share/lhapdf/PDFsets ]] 
 then
   export LHAPATH=${OPT_SPHENIX}/lhapdf-5.9.1/share/lhapdf/PDFsets
@@ -263,6 +258,11 @@ then
 	ldpath=${G4_MAIN}/lib64:$ldpath
     fi
 fi
+if [[ -z "$XERCESCROOT" ]]
+then
+  export XERCESCROOT=${G4_MAIN}
+fi
+
 
 #Pythia8
 if [[ -z PYTHIA8 && -d $OFFLINE_MAIN/share/Pythia8 ]]


### PR DESCRIPTION
… - it is installed under G4_MAIN (in case we use a non default g4 version)