### PR TITLE
unset XERCESCROOT to be able to switch to the play build

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -52,6 +52,7 @@ unalias pwd
 if ($opt_n) then
   unsetenv CERN*
   unsetenv CALIBRATIONROOT
+  unsetenv CONFIG_SITE
   unsetenv COVERITY_ROOT
   unsetenv CVSROOT
   unsetenv G4*
@@ -68,6 +69,7 @@ if ($opt_n) then
   unsetenv ROOTSYS
   unsetenv SIMULATION_MAIN
   unsetenv TSEARCHPATH
+  unsetenv XERCESCROOT
 endif
 
 # set afs sysname to replace @sys so links stay functional even if

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -67,6 +67,7 @@ if [ $opt_n != 0 ]
   unset ROOTSYS
   unset SIMULATION_MAIN
   unset TSEARCHPATH
+  unset XERCESCROOT
 fi
 
 # set afs sysname to replace @sys so links stay functional even if


### PR DESCRIPTION
This should finally fix the crashing play builds which use a newer G4 version