### PR TITLE
get afs sphenix environment

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -104,14 +104,14 @@ else
 endif
 
 if (! $?OPT_SPHENIX) then
-  if (-d /opt/sphenix/core) then
-    setenv OPT_SPHENIX /opt/sphenix/core
+  if (-d /afs/rhic.bnl.gov/opt/sphenix/core) then
+    setenv OPT_SPHENIX /afs/rhic.bnl.gov/opt/sphenix/core
   endif
 endif
 
 if (! $?OPT_UTILS) then
-  if (-d /opt/sphenix/utils) then
-    setenv OPT_UTILS /opt/sphenix/utils
+  if (-d /afs/rhic.bnl.gov/opt/sphenix/utils) then
+    setenv OPT_UTILS /afs/rhic.bnl.gov/opt/sphenix/utils
   endif
 endif
 

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -104,14 +104,14 @@ else
     unset ORIG_MANPATH
 fi
 
-if [[ -z "$OPT_SPHENIX" && -d /opt/sphenix/core ]]
+if [[ -z "$OPT_SPHENIX" && -d /afs/rhic.bnl.gov/opt/sphenix/core ]]
 then
-  export OPT_SPHENIX=/opt/sphenix/core
+  export OPT_SPHENIX=/afs/rhic.bnl.gov/opt/sphenix/core
 fi
 
-if [[ -z "$OPT_UTILS" && -d /opt/sphenix/utils ]]
+if [[ -z "$OPT_UTILS" && -d /afs/rhic.bnl.gov/opt/sphenix/utils ]]
 then
-    export OPT_UTILS=/opt/sphenix/utils
+    export OPT_UTILS=/afs/rhic.bnl.gov/opt/sphenix/utils
 fi
 
 # set site wide compiler options (no rpath hardcoding)


### PR DESCRIPTION
now that we have switched /opt/sphenix to point to cvmfs it needs a small change to switch to the afs environment - replacing /opt/sphenix by /afs/rhic.bnl.gov/opt/sphenix in the setting of OPT_SPHENIX and OPT_UTILS