### PR TITLE
use with /opt/sphenix -> /cvmfs

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -105,14 +105,14 @@ else
 endif
 
 if (! $?OPT_SPHENIX) then
-  if (-d /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core) then
-    setenv OPT_SPHENIX /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core
+  if (-d /opt/sphenix/core) then
+    setenv OPT_SPHENIX /opt/sphenix/core
   endif
 endif
 
 if (! $?OPT_UTILS) then
-  if (-d /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/utils) then
-    setenv OPT_UTILS /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/utils
+  if (-d /opt/sphenix/utils) then
+    setenv OPT_UTILS /opt/sphenix/utils
   endif
 endif
 
@@ -221,7 +221,7 @@ if (! $?G4_MAIN) then
 endif
 
 if (-d $G4_MAIN) then
-# normalize G4_MAIN to /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/phenix/geant4.Version
+# normalize G4_MAIN to /opt/phenix/geant4.Version
     set here=`pwd`
     cd $G4_MAIN
     set there=`pwd -P`

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -105,14 +105,14 @@ else
     unset ORIG_MANPATH
 fi
 
-if [[ -z "$OPT_SPHENIX" && -d /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core ]]
+if [[ -z "$OPT_SPHENIX" && -d /opt/sphenix/core ]]
 then
-  export OPT_SPHENIX=/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core
+  export OPT_SPHENIX=/opt/sphenix/core
 fi
 
-if [[ -z "$OPT_UTILS" && -d /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/utils ]]
+if [[ -z "$OPT_UTILS" && -d /opt/sphenix/utils ]]
 then
-    export OPT_UTILS=/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/utils
+    export OPT_UTILS=/opt/sphenix/utils
 fi
 
 # set site wide compiler options (no rpath hardcoding)


### PR DESCRIPTION
the setup script needs a small change so the containers which use /opt/sphenix can run it. This is basically the cvmfs version of our setup scripts (also enabling pyroot)