### PR TITLE
Debug build

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -117,8 +117,16 @@ if (! $?OPT_UTILS) then
 endif
 
 # set site wide compiler options (no rpath hardcoding)
-if (-f ${OPT_SPHENIX}/etc/config.site) then
-  setenv CONFIG_SITE ${OPT_SPHENIX}/etc/config.site
+if (! $?CONFIG_SITE) then
+  if ($opt_v =~ "debug" ) then
+    if (-f ${OPT_SPHENIX}/etc/config_debug.site) then
+      setenv CONFIG_SITE ${OPT_SPHENIX}/etc/config_debug.site
+    endif
+  else
+    if (-f ${OPT_SPHENIX}/etc/config.site) then
+      setenv CONFIG_SITE ${OPT_SPHENIX}/etc/config.site
+    endif
+  endif
 endif
 # Perl
 if (! $?PERL5LIB) then

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -116,11 +116,18 @@ then
 fi
 
 # set site wide compiler options (no rpath hardcoding)
-if [[ -z "$CONFIG_SITE" && -f ${OPT_SPHENIX}/etc/config.site ]]
+if [[ -z "$CONFIG_SITE" ]]
 then
-  export CONFIG_SITE=${OPT_SPHENIX}/etc/config.site
+  if [[ $opt_v = "debug" && -f ${OPT_SPHENIX}/etc/config_debug.site ]]
+  then
+    export CONFIG_SITE=${OPT_SPHENIX}/etc/config_debug.site
+  else
+    if [ -f ${OPT_SPHENIX}/etc/config_debug.site ]
+    then
+      export CONFIG_SITE=${OPT_SPHENIX}/etc/config.site
+    fi
+  fi
 fi
-
 # Perl
 if [ -z "$PERL5LIB" ]
 then

--- a/etc/config_debug.site
+++ b/etc/config_debug.site
@@ -1,0 +1,4 @@
+# enable c++11 flag by default
+CXXFLAGS="-g -std=c++11"
+# Allow LD_LIBRARY_PATH to override RPATH
+LDFLAGS='-Wl,--enable-new-dtags'


### PR DESCRIPTION
Just changing the CXXFLAGS in the config.site is the easiest way to get consistent builds using -std=c++11 which is set to our default in this file, rather than overriding CXXFLAGS for every single package. This needed to be propagated to the setup scripts which now set CONFIG_SITE to ${OPT_SPHENIX}/etc/config_debug.site if sourced with debug