### PR TITLE
Fix argument handling

### DIFF
--- a/bin/setup_root6.csh
+++ b/bin/setup_root6.csh
@@ -4,24 +4,26 @@ setenv EVT_LIB $ROOTSYS/lib
 set first=1
 set offline_main_done=0
 # make sure our include dirs come first in ROOT_INCLUDE_PATH, 
-# use OFFLINE_MAIN only if it comes in the list of arguments
+# use OFFLINE_MAIN only if it comes in the list of arguments, flag it as used
 if ($#argv > 0) then
   foreach arg ($*)
     if ($arg =~ *"$OFFLINE_MAIN"*) then
       set offline_main_done=1
     endif
-    foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
-      if (-d $incdir) then
-        if ($first == 1) then
-          setenv ROOT_INCLUDE_PATH $incdir
-          set first=0
-        else
-          if ($incdir !~ {*CGAL}) then
-            setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+    if (-d $arg) then
+      foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
+        if (-d $incdir) then
+          if ($first == 1) then
+            setenv ROOT_INCLUDE_PATH $incdir
+            set first=0
+          else
+            if ($incdir !~ {*CGAL}) then
+              setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+            endif
           endif
         endif
-      endif
-    end
+      end
+    endif
   end
 endif  
 # add OFFLINE_MAIN include paths by default if not already done

--- a/bin/setup_root6.csh
+++ b/bin/setup_root6.csh
@@ -2,9 +2,14 @@
 unsetenv ROOT_INCLUDE_PATH
 setenv EVT_LIB $ROOTSYS/lib
 set first=1
-# make sure our include dirs come first in ROOT_INCLUDE_PATH
+set offline_main_done=0
+# make sure our include dirs come first in ROOT_INCLUDE_PATH, 
+# use OFFLINE_MAIN only if it comes in the list of arguments
 if ($#argv > 0) then
   foreach arg ($*)
+    if ($arg =~ *"$OFFLINE_MAIN"*) then
+      set offline_main_done=1
+    endif
     foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
       if (-d $incdir) then
         if ($first == 1) then
@@ -19,18 +24,21 @@ if ($#argv > 0) then
     end
   end
 endif  
-foreach incdir (`find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`)
-  if (-d $incdir) then
-    if ($first == 1) then
-      setenv ROOT_INCLUDE_PATH $incdir
-      set first=0
-    else
-      if ($incdir !~ {*CGAL}) then
-        setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+# add OFFLINE_MAIN include paths by default if not already done
+if ($offline_main_done == 0) then
+  foreach incdir (`find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`)
+    if (-d $incdir) then
+      if ($first == 1) then
+        setenv ROOT_INCLUDE_PATH $incdir
+        set first=0
+      else
+        if ($incdir !~ {*CGAL}) then
+          setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+        endif
       endif
     endif
-  endif
-end
+  end
+endif
 # add G4 include path
 setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$G4_MAIN/include
 #echo $ROOT_INCLUDE_PATH

--- a/bin/setup_root6.sh
+++ b/bin/setup_root6.sh
@@ -2,45 +2,57 @@
 unset ROOT_INCLUDE_PATH
 export EVT_LIB=$ROOTSYS/lib
 first=1
+offline_main_done=0
 # make sure our include dirs come first in ROOT_INCLUDE_PATH
+# use OFFLINE_MAIN only if it comes in the list of arguments, flag it as used
 if [ $# > 0 ]
 then
   for arg in "$@"
   do
-    for incdir in `find $arg/include -maxdepth 1 -type d -print`
-    do
-      if [ -d $incdir ] 
-      then
-        if [ $first == 1 ] 
+    if [ $arg = "$OFFLINE_MAIN" ]
+    then
+      offline_main_done=1
+    fi
+    if [ -d $arg ]
+    then
+      for incdir in `find $arg/include -maxdepth 1 -type d -print`
+      do
+        if [ -d $incdir ] 
         then
-          root_include_path=$incdir
-          first=0
-        else
-          if [[ $incdir != *"CGAL"* ]]
+          if [ $first == 1 ] 
           then
-            root_include_path=$root_include_path:$incdir
+            root_include_path=$incdir
+            first=0
+          else
+            if [[ $incdir != *"CGAL"* ]]
+            then
+              root_include_path=$root_include_path:$incdir
+            fi
           fi
         fi
-      fi
-    done
+      done
+    fi
   done
 fi 
-for incdir in `find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`
-do
-  if [ -d $incdir ]
-   then
-    if [ $first == 1 ]
+if [ $offline_main_done == 0 ]
+then
+  for incdir in `find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`
+  do
+    if [ -d $incdir ]
     then
-      root_include_path=$incdir
-      first=0
-    else
-      if [[ $incdir != *"CGAL"* ]]
+      if [ $first == 1 ]
       then
-        root_include_path=$root_include_path:$incdir
+        root_include_path=$incdir
+        first=0
+      else
+        if [[ $incdir != *"CGAL"* ]]
+        then
+          root_include_path=$root_include_path:$incdir
+        fi
       fi
     fi
-  fi
-done
+  done
+fi
 root_include_path=$root_include_path:$G4_MAIN/include
 # add G4 include path
 export ROOT_INCLUDE_PATH=$root_include_path

--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -363,8 +363,5 @@ setenv PATH `echo -n $PATH | sed 's/.$//'`
 setenv LD_LIBRARY_PATH `echo -n $LD_LIBRARY_PATH | sed 's/.$//'`
 setenv MANPATH `echo -n $MANPATH | sed 's/.$//'`
 
-#set ROOT_INCLUDE_PATH
-while ($# > 0)
-shift
-end
-source $OPT_SPHENIX/bin/setup_root6.csh
+#set ROOT_INCLUDE_PATH for root6
+source $OPT_SPHENIX/bin/setup_root6.csh $OFFLINE_MAIN

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -407,8 +407,4 @@ unset manpath
 export PATH
 export LD_LIBRARY_PATH
 export MANPATH
-while (( "$#" )); 
-do
-  shift
-done
-source $OPT_SPHENIX/bin/setup_root6.sh 
+source $OPT_SPHENIX/bin/setup_root6.sh $OFFLINE_MAIN


### PR DESCRIPTION
the previous version was a quick hack to avoid random user arguments which get passed to the sphenix_setup script to confuse the setup_root6 script. Calling this script now with $OFFLINE_MAIN takes care of that. This also prevents adding offline_main includes twice in case a user calls the setup_root6 script with OFFLINE_MAIN as argument. 