### PR TITLE
change python version back to 3.6

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -216,7 +216,7 @@ endif
 
 #add our python packages and path to ROOT.py
 if (! $?PYTHONPATH) then
-  setenv PYTHONPATH ${OPT_SPHENIX}/pythonpackages/lib/python3.7/site-packages:${OPT_UTILS}/lib/python3.7/site-packages:${ROOTSYS}/lib
+  setenv PYTHONPATH ${OPT_SPHENIX}/pythonpackages/lib/python3.6/site-packages:${OPT_UTILS}/lib/python3.6/site-packages:${ROOTSYS}/lib
 endif
 
 # Add Geant4

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -231,9 +231,9 @@ then
   fi
 fi
 
-if [[ -z "$PYTHONPATH" && -d ${OPT_SPHENIX}/pythonpackages/lib/python3.7/site-packages ]]
+if [[ -z "$PYTHONPATH" && -d ${OPT_SPHENIX}/pythonpackages/lib/python3.6/site-packages ]]
 then
-  export PYTHONPATH=${OPT_SPHENIX}/pythonpackages/lib/python3.7/site-packages:${OPT_UTILS}/lib/python3.7/site-packages:${ROOTSYS}/lib
+  export PYTHONPATH=${OPT_SPHENIX}/pythonpackages/lib/python3.6/site-packages:${OPT_UTILS}/lib/python3.6/site-packages:${ROOTSYS}/lib
 fi
 
 # Add Geant4


### PR DESCRIPTION
We have to fall back to python 3.6, these &*#^$*^ exported a private symbol which prevents root6 from linking. We are not alone:
https://bugzilla.redhat.com/show_bug.cgi?id=1596902
It also has an API change from char * to const char * which makes minor code changes in root5 and root6 necessary (which doesn't feel good either)