### PR TITLE
only add absolutely needed paths from OFFLINE_MAIN, not all subdirs

### DIFF
--- a/bin/setup_root6.csh
+++ b/bin/setup_root6.csh
@@ -9,37 +9,40 @@ if ($#argv > 0) then
   foreach arg ($*)
     if ($arg =~ *"$OFFLINE_MAIN"*) then
       set offline_main_done=1
-    endif
-    if (-d $arg) then
-      foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
-        if (-d $incdir) then
-          if ($first == 1) then
-            setenv ROOT_INCLUDE_PATH $incdir
-            set first=0
-          else
-            if ($incdir !~ {*CGAL}) then
-              setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+      if ($first == 1) then
+        setenv ROOT_INCLUDE_PATH $OFFLINE_MAIN/include
+        set first=0
+      else
+        setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include
+      endif
+      setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase
+    else
+      if (-d $arg) then
+        foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
+          if (-d $incdir) then
+            if ($first == 1) then
+              setenv ROOT_INCLUDE_PATH $incdir
+              set first=0
+            else
+              if ($incdir !~ {*CGAL}) then
+                setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+              endif
             endif
           endif
-        endif
-      end
+        end
+      endif
     endif
   end
 endif  
 # add OFFLINE_MAIN include paths by default if not already done
 if ($offline_main_done == 0) then
-  foreach incdir (`find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`)
-    if (-d $incdir) then
-      if ($first == 1) then
-        setenv ROOT_INCLUDE_PATH $incdir
-        set first=0
-      else
-        if ($incdir !~ {*CGAL}) then
-          setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
-        endif
-      endif
-    endif
-  end
+  if ($first == 1) then
+    setenv ROOT_INCLUDE_PATH $OFFLINE_MAIN/include
+    set first=0
+  else
+    setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include
+  endif
+  setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase
 endif
 # add G4 include path
 setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$G4_MAIN/include

--- a/bin/setup_root6.sh
+++ b/bin/setup_root6.sh
@@ -12,46 +12,48 @@ then
     if [ $arg = "$OFFLINE_MAIN" ]
     then
       offline_main_done=1
-    fi
-    if [ -d $arg ]
-    then
-      for incdir in `find $arg/include -maxdepth 1 -type d -print`
-      do
-        if [ -d $incdir ] 
-        then
-          if [ $first == 1 ] 
+      if [ $first == 1 ] 
+      then
+        root_include_path=$OFFLINE_MAIN/include
+        first=0
+      else
+        root_include_path=$root_include_path:$OFFLINE_MAIN/include
+      fi
+root_include_path=$root_include_path:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase
+    else
+      if [ -d $arg ]
+      then
+        for incdir in `find $arg/include -maxdepth 1 -type d -print`
+        do
+          if [ -d $incdir ] 
           then
-            root_include_path=$incdir
-            first=0
-          else
-            if [[ $incdir != *"CGAL"* ]]
+            if [ $first == 1 ] 
             then
-              root_include_path=$root_include_path:$incdir
+              root_include_path=$incdir
+              first=0
+            else
+              if [[ $incdir != *"CGAL"* ]]
+              then
+                root_include_path=$root_include_path:$incdir
+              fi
             fi
           fi
-        fi
-      done
+        done
+      fi
     fi
   done
 fi 
 if [ $offline_main_done == 0 ]
 then
-  for incdir in `find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`
-  do
-    if [ -d $incdir ]
-    then
-      if [ $first == 1 ]
-      then
-        root_include_path=$incdir
-        first=0
-      else
-        if [[ $incdir != *"CGAL"* ]]
-        then
-          root_include_path=$root_include_path:$incdir
-        fi
-      fi
-    fi
-  done
+  offline_main_done=1
+  if [ $first == 1 ] 
+  then
+    root_include_path=$OFFLINE_MAIN/include
+    first=0
+  else
+    root_include_path=$root_include_path:$OFFLINE_MAIN/include
+  fi
+  root_include_path=$root_include_path:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase
 fi
 root_include_path=$root_include_path:$G4_MAIN/include
 # add G4 include path


### PR DESCRIPTION
Up to now the script loops over all subdirs under $OFFLINE_MAIN/include and adds them to the ROOT_INCLUDE_PATH. This is not needed anymore - we are still left with 4 oddball subdirs which are needed but adding all is an overkill and might hide problems in the code. Now those oddball subdirs are hardcoded into the include path. It still loops over the user install area (if given) and adds all subdirs.