### PR TITLE
scripts which set up private install areas correctly

### DIFF
--- a/bin/setup_local.csh
+++ b/bin/setup_local.csh
@@ -1,0 +1,26 @@
+#! /bin/csh -f -x
+if ($#argv > 0) then
+  source /opt/sphenix/core/bin/setup_root6.csh $*
+  set ldpath = ""
+  set bpath = ""
+  set first=1
+  foreach arg ($*)
+    set libpath = $arg/lib
+    set binpath = $arg/bin
+    if (-d $libpath) then
+      if ($first == 1) then
+        set ldpath = $libpath
+        set first=0
+      else
+        set ldpath =  ${ldpath}:${libpath}
+      endif
+    endif
+    if (-d $binpath) then
+      set bpath=($bpath $binpath)
+    endif
+  end
+setenv LD_LIBRARY_PATH ${ldpath}:$LD_LIBRARY_PATH
+set path = ($bpath $path)
+endif  
+echo LD_LIBRARY_PATH now $LD_LIBRARY_PATH
+echo path now $path

--- a/bin/setup_local.sh
+++ b/bin/setup_local.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+if [ $# > 0 ]
+then
+  firsta=1
+  firstb=1
+  ldpath=""
+  bpath=""
+  source /opt/sphenix/core/bin/setup_root6.sh $@
+  for arg in "$@"
+  do
+    libpath=$arg/lib
+    binpath=$arg/bin
+    if [ -d $libpath ]
+    then
+      if [ $firsta == 1 ]
+      then
+        ldpath=$libpath
+        firsta=0
+      else
+        ldpath=${ldpath}:${libpath}
+      fi
+    fi
+    if [ -d $binpath ]
+    then
+      if [ $firstb == 1 ]
+      then
+        bpath=$binpath
+        firstb=0
+      else
+        bpath=${bpath}:${binpath}
+      fi
+    fi
+  done
+  export LD_LIBRARY_PATH=${ldpath}:$LD_LIBRARY_PATH
+  export PATH=${bpath}:${PATH}
+  echo LD_LIBRARY_PATH now $LD_LIBRARY_PATH
+  echo PATH now $PATH
+fi


### PR DESCRIPTION
This PR adds a script (bash and tcsh) which sets up the PATH, LD_LIBRARY_PATH and ROOT_INCLUDE_PATH correctly for private install areas. Multiple install areas can be given, they are added in the order they are given (the first one being first in the path)