### PR TITLE
Add g4main to ROOT_INCLUDE_PATH

### DIFF
--- a/bin/setup_root6.csh
+++ b/bin/setup_root6.csh
@@ -15,7 +15,7 @@ if ($#argv > 0) then
       else
         setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include
       endif
-      setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
+      setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/g4main:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
     else
       if (-d $arg) then
         foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
@@ -42,7 +42,7 @@ if ($offline_main_done == 0) then
   else
     setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include
   endif
-  setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
+  setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/g4main:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
 endif
 # add G4 include path
 setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$G4_MAIN/include

--- a/bin/setup_root6.sh
+++ b/bin/setup_root6.sh
@@ -19,7 +19,7 @@ then
       else
         root_include_path=$root_include_path:$OFFLINE_MAIN/include
       fi
-root_include_path=$root_include_path:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
+root_include_path=$root_include_path:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/g4main:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
     else
       if [ -d $arg ]
       then
@@ -53,7 +53,7 @@ then
   else
     root_include_path=$root_include_path:$OFFLINE_MAIN/include
   fi
-  root_include_path=$root_include_path:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
+  root_include_path=$root_include_path:$OFFLINE_MAIN/include/eigen3:$OFFLINE_MAIN/include/GenFit:$OFFLINE_MAIN/include/g4detectors:$OFFLINE_MAIN/include/g4main:$OFFLINE_MAIN/include/phhepmc:$OFFLINE_MAIN/include/calobase:$OFFLINE_MAIN/include/trackbase_historic
 fi
 root_include_path=$root_include_path:$G4_MAIN/include
 # add G4 include path


### PR DESCRIPTION
It is still a mystery how root6 deals with the include path. The EIC macro stopped to work with the latest PR without having g4main in the include path (barfs with #include "PHG4HitDefs.h").