### PR TITLE
make insure 7.5.2 the default

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -266,7 +266,7 @@ endif
 
 # Set up Insure++, if we have it
 if (! $?PARASOFT) then
-  setenv PARASOFT /afs/rhic.bnl.gov/app/insure-7.5.0
+  setenv PARASOFT /afs/rhic.bnl.gov/app/insure-7.5.2
 endif
 
 # Coverity

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -292,7 +292,7 @@ fi
 # Set up Insure++, if we have it
 if [ -z  "$PARASOFT" ] 
 then
-  export PARASOFT=/afs/rhic.bnl.gov/app/insure-7.5.0
+  export PARASOFT=/afs/rhic.bnl.gov/app/insure-7.5.2
 fi
 
 # Coverity


### PR DESCRIPTION
This PR switches our insure version to the newest version (no it doesn't work just like the other ones, we do not have a root insure exec)