### PR TITLE
oops, forgot a $ in the env var check

### DIFF
--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -291,7 +291,7 @@ then
 fi
 
 #Sartre
-if [[ -z "SARTRE_DIR" && -d $OFFLINE_MAIN/sartre ]]
+if [[ -z "$SARTRE_DIR" && -d $OFFLINE_MAIN/sartre ]]
 then
   export SARTRE_DIR=$OFFLINE_MAIN/sartre
 fi


### PR DESCRIPTION
This PR fixes the missing SARTRE_DIR env var from the sphenix setup script