### PR TITLE
use location of setup script to determine installation location

### DIFF
--- a/bin/setup_local.csh
+++ b/bin/setup_local.csh
@@ -1,6 +1,11 @@
 #! /bin/csh -f -x
+if (! $?OPT_SPHENIX) then
+  echo OPT_SPHENIX environment variable not set, source the sphenix_setup script
+  echo before sourcing this script
+  exit 1
+endif
 if ($#argv > 0) then
-  source /opt/sphenix/core/bin/setup_root6_include_path.csh $*
+  source ${OPT_SPHENIX}/bin/setup_root6_include_path.csh $*
   set ldpath = ""
   set bpath = ""
   set first=1

--- a/bin/setup_local.sh
+++ b/bin/setup_local.sh
@@ -1,11 +1,17 @@
 #! /bin/bash
+if [ -z "$OPT_SPHENIX" ]
+then
+  echo OPT_SPHENIX environment variable not set, source the sphenix_setup script
+  echo before sourcing this script
+  exit 1
+fi
 if [ $# > 0 ]
 then
   firsta=1
   firstb=1
   ldpath=""
   bpath=""
-  source /opt/sphenix/core/bin/setup_root6_include_path.sh $@
+  source ${OPT_SPHENIX}/bin/setup_root6_include_path.sh $@
   for arg in "$@"
   do
     libpath=$arg/lib

--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -18,9 +18,24 @@
 # use "limit coredumpsize unlimited" to undo this.
 limit coredumpsize 0
 
+# find out if we are sourced or not, sadly the extraction of the
+# name and full path of this script depend on this
+set sourced=($_)
+if ("$0" == "-tcsh") then
+set this_script=$sourced[2]
+else
+set this_script="$0"
+endif
+
+#
+# Absolute path to this script, everything is relative to this path
+#
+set this_script=`readlink -f $this_script`
+
 set opt_a = 0
 set opt_n = 0
 set opt_v = "new"
+set opt_b = "none"
 
 foreach arg ($*)
     switch ($arg)
@@ -29,6 +44,9 @@ foreach arg ($*)
 	breaksw
     case "-n":
         set opt_n = 1
+	breaksw
+    case "-b*":
+        set opt_b =  $arg
 	breaksw
     case "-*":
         echo "usage source sphenix_setup.csh [-a] [-n] [-h] [version]"
@@ -42,6 +60,8 @@ foreach arg ($*)
 	breaksw
     endsw
 end
+# strip the -b from the base installation area
+set force_base=`echo $opt_b | awk '{print substr($0,3)}'`
 
 # STARs environment contains an alias for pwd which
 # throws a monkey wrench into pwd -P
@@ -74,6 +94,8 @@ if ($opt_n) then
   unsetenv XERCESCROOT
 endif
 
+# we do not use afs anymore, I leave this in place in case
+# we need to use it in the future
 # set afs sysname to replace @sys so links stay functional even if
 # the afs sysname changes in the future
 set sysname=`/usr/bin/fs sysname | sed "s/^.*'\(.*\)'.*/\1/"`
@@ -91,7 +113,7 @@ setenv DCACHE_RAHEAD
 setenv DCACHE_RA_BUFFER 2097152
 
 
-# Make copies of PATH and LD_LIBRARY_PATH as they were
+# Make copies of PATH, LD_LIBRARY_PATH and MANPATH as they were
 setenv ORIG_PATH ${PATH}
 if ($?LD_LIBRARY_PATH) then
     setenv ORIG_LD_LIBRARY_PATH ${LD_LIBRARY_PATH}
@@ -105,16 +127,26 @@ else
     unsetenv ORIG_MANPATH
 endif
 
+# Absolute path of this script
+set scriptpath=`dirname "$this_script"`
+# extract base path (everything before /opt/sphenix)
+set optsphenixindex=`echo $scriptpath | awk '{print index($0,"/opt/sphenix")}'`
+set optbasepath=`echo $scriptpath | awk '{print substr($0,0,'$optsphenixindex'-1)}'`
+
+# just in case the above screws up, give it the default in rcf
+if (! -d $optbasepath) then
+  set optbasepath="/opt/sphenix"
+endif
+if (-d $force_base) then
+  set optbasepath=$force_base
+endif
+
 if (! $?OPT_SPHENIX) then
-  if (-d /opt/sphenix/core) then
-    setenv OPT_SPHENIX /opt/sphenix/core
-  endif
+  setenv OPT_SPHENIX ${optbasepath}/opt/sphenix/core
 endif
 
 if (! $?OPT_UTILS) then
-  if (-d /opt/sphenix/utils) then
-    setenv OPT_UTILS /opt/sphenix/utils
-  endif
+  setenv OPT_UTILS ${optbasepath}/opt/sphenix/utils
 endif
 
 # set site wide compiler options (no rpath hardcoding)
@@ -149,10 +181,10 @@ endif
 
 # OFFLINE
 if (! $?OFFLINE_MAIN) then
-  if (! -d /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/$opt_v) then
+  if (! -d ${optbasepath}/release/$opt_v) then
     set opt_v = "new"
   endif
-  setenv OFFLINE_MAIN /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/$opt_v
+  setenv OFFLINE_MAIN ${optbasepath}/release/$opt_v
 endif
 
 if ($OFFLINE_MAIN =~ *"insure"* ) then
@@ -230,7 +262,7 @@ if (! $?G4_MAIN) then
 endif
 
 if (-d $G4_MAIN) then
-# normalize G4_MAIN to /opt/phenix/geant4.Version
+# normalize G4_MAIN to ${optbasepath}/opt/sphenix/core/geant4.Version
     set here=`pwd`
     cd $G4_MAIN
     set there=`pwd -P`
@@ -258,7 +290,6 @@ endif
 if (! $?XERCESCROOT) then
   setenv XERCESCROOT $G4_MAIN
 endif
-
 
 #Pythia8
 if (! $?PYTHIA8) then
@@ -292,19 +323,19 @@ if (! $?PGHOST) then
 endif
 
 # set initial paths, all following get prepended
-set path = (/usr/lib64/qt-3.3/bin /usr/local/bin /usr/bin /usr/local/sbin /usr/sbin)
+set path = (/usr/local/bin /usr/bin /usr/local/sbin /usr/sbin)
 set manpath = `/usr/bin/man --path`
 
 set ldpath = /usr/local/lib64:/usr/lib64
 
 # loop over all bin dirs and prepend to path
-foreach bindir ($COVERITY_ROOT/bin \
+foreach bindir (${COVERITY_ROOT}/bin \
                 ${PARASOFT}/bin \
-                $G4_MAIN/bin \
+                ${G4_MAIN}/bin \
                 $rootbindir \
-                $OPT_SPHENIX/bin \
-                $OPT_UTILS/bin \
-                $ONLINE_MAIN/bin \
+                ${OPT_SPHENIX}/bin \
+                ${OPT_UTILS}/bin \
+                ${ONLINE_MAIN}/bin \
                 ${OFFLINE_MAIN}/bin)
   if (-d $bindir) then
     set path = ($bindir $path)
@@ -316,8 +347,8 @@ foreach libdir (${PARASOFT}/lib \
                 ${OPT_SPHENIX}/lhapdf-5.9.1/lib \
                 ${G4_MAIN}/lib64 \
                 ${rootlibdir} \
-                $OPT_SPHENIX/lib \
-                $OPT_UTILS/lib \
+                ${OPT_SPHENIX}/lib \
+                ${OPT_UTILS}/lib \
                 ${ONLINE_MAIN}/lib \
                 ${OFFLINE_MAIN}/lib)
   if (-d $libdir) then
@@ -330,7 +361,7 @@ foreach mandir (${ROOTSYS}/man \
                 ${OPT_SPHENIX}/share/man \
                 ${OPT_UTILS}/man \
                 ${OPT_UTILS}/share/man \
-                $OFFLINE_MAIN/share/man)
+                ${OFFLINE_MAIN}/share/man)
   if (-d $mandir) then
     set manpath = ${mandir}:${manpath}
   endif

--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -49,8 +49,9 @@ foreach arg ($*)
         set opt_b =  $arg
 	breaksw
     case "-*":
-        echo "usage source sphenix_setup.csh [-a] [-n] [-h] [version]"
+        echo "usage source sphenix_setup.csh [-a] [-b[base dir]] [-n] [-h] [version]"
         echo "-a: append path and LD_LIBRARY_PATH to existing ones"
+        echo "-b: override base directory for installation (default script dir), no space between -b and directory"
         echo "-n: overwrite all environment variables, needed for switching builds"
         echo "version: build version (new, ana, pro, play,... - also with version number e.g. ana.407)"
         exit(0)

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -22,6 +22,13 @@ ulimit -c 0
 opt_a=0
 opt_n=0
 opt_v="new"
+opt_b="none"
+
+this_script=$BASH_SOURCE
+#
+# Absolute path to this script, everything is relative to this path
+#
+this_script=`readlink -f $this_script`
 
 for arg in "$@"
 do
@@ -32,6 +39,9 @@ do
     -n)
         opt_n=1
 	;;
+    -b*)
+        opt_b=$arg
+        ;;
     -*)
         echo "usage source sphenix_setup.csh [-a] [-n] [-h] [version]"
         echo "-a: append path and LD_LIBRARY_PATH to existing ones"
@@ -44,6 +54,8 @@ do
 	;;
     esac
 done
+# strip the -b from the base installation area
+force_base=`echo $opt_b | awk '{print substr($0,3)}'`
 
 
 # if -n unset all relevant environment variables
@@ -106,14 +118,31 @@ else
     unset ORIG_MANPATH
 fi
 
-if [[ -z "$OPT_SPHENIX" && -d /opt/sphenix/core ]]
+# Absolute path of this script
+scriptpath=`dirname "$this_script"`
+# extract base path (everything before /opt/sphenix)
+optsphenixindex=`echo $scriptpath | awk '{print index($0,"/opt/sphenix")}'`
+optbasepath=`echo $scriptpath | awk '{print substr($0,0,'$optsphenixindex'-1)}'`
+
+
+# just in case the above screws up, give it the default in rcf
+if [ ! -d $optbasepath ]
 then
-  export OPT_SPHENIX=/opt/sphenix/core
+  optbasepath="/opt/sphenix"
+fi
+if [ -d $force_base ]
+then
+  optbasepath=$force_base
 fi
 
-if [[ -z "$OPT_UTILS" && -d /opt/sphenix/utils ]]
+if [[ -z "$OPT_SPHENIX" && -d ${optbasepath}/opt/sphenix/core ]]
 then
-    export OPT_UTILS=/opt/sphenix/utils
+  export OPT_SPHENIX=${optbasepath}/opt/sphenix/core
+fi
+
+if [[ -z "$OPT_UTILS" && -d ${optbasepath}/opt/sphenix/utils ]]
+then
+    export OPT_UTILS=${optbasepath}/opt/sphenix/utils
 fi
 
 # set site wide compiler options (no rpath hardcoding)
@@ -154,11 +183,11 @@ fi
 
 if [ -z "$OFFLINE_MAIN" ]
 then
-  if [ ! -d /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/$opt_v ]
+  if [ ! -d ${optbasepath}/release/$opt_v ]
   then
     opt_v="new"
   fi
-  export OFFLINE_MAIN=/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/$opt_v
+  export OFFLINE_MAIN=${optbasepath}/release/$opt_v
 fi
 
 if [[ $OFFLINE_MAIN = *insure* ]]

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -43,8 +43,9 @@ do
         opt_b=$arg
         ;;
     -*)
-        echo "usage source sphenix_setup.csh [-a] [-n] [-h] [version]"
+        echo "usage source sphenix_setup.csh [-a] [-b[base dir]] [-n] [-h] [version]"
         echo "-a: append path and LD_LIBRARY_PATH to existing ones"
+        echo "-b: override base directory for installation (default script dir), no space between -b and directory"
         echo "-n: overwrite all environment variables, needed for switching builds"
         echo "version: build version (new, ana, pro, play,... - also with version number e.g. ana.407)"
         exit 0


### PR DESCRIPTION
our initial cvmfs volume /cvmfs/sphenix.sdcc.bnl.gov was hardcoded in a few places which threw the use of our OSG volume /cvmfs/sphenix.opensciencegrid.org off. Now the location of the sphenix_setup scripts is used to determine the installation location. The setup scripts have an option to override this but I would use this only for testing a modified script