### PR TITLE
unset environment variables which are set by gcc 8.3

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -51,6 +51,14 @@ end
 # throws a monkey wrench into pwd -P
 unalias pwd
 
+# unset compiler settings from gcc 8.3 they will be set again
+# in the respective gcc 8.3 setup, but they wreak havoc if you
+# leave them when using another compiler
+unsetenv FC
+unsetenv CC
+unsetenv CXX
+unsetenv COMPILER_PATH
+
 # if -n unset all relevant environment variables
 # also from phenix setup script so we can switch
 if ($opt_n) then

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -64,6 +64,14 @@ do
     esac
 done
 
+# unset compiler settings from gcc 8.3 they will be set again
+# in the respective gcc 8.3 setup, but they wreak havoc if you
+# leave them when using another compiler
+unset FC
+unset CC
+unset CXX
+unset COMPILER_PATH
+
 # if -n unset all relevant environment variables
 # also from phenix setup script so we can switch
 if [ $opt_n != 0 ]


### PR DESCRIPTION
The gcc 8.3 setup script sets a few environment variables which need to be unset, otherwise you will use that compiler even when switching environments