### PR TITLE
add softlinks for eic setup, pointing to sphenix setup

### DIFF
--- a/bin/eic_setup.csh
+++ b/bin/eic_setup.csh
@@ -1,0 +1,1 @@
+sphenix_setup.csh

--- a/bin/eic_setup.sh
+++ b/bin/eic_setup.sh
@@ -1,0 +1,1 @@
+sphenix_setup.sh


### PR DESCRIPTION
This PR just adds softlinks so eic users do not have to source an sphenix setup script