### PR TITLE
in case afs is missing, set sysname to x8664_sl7

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -85,11 +85,13 @@ if ($opt_n) then
   unsetenv TSEARCHPATH
   unsetenv XERCESCROOT
 endif
-
 # set afs sysname to replace @sys so links stay functional even if
 # the afs sysname changes in the future
-set sysname=`/usr/bin/fs sysname | sed "s/^.*'\(.*\)'.*/\1/"`
-
+if (-f /usr/bin/fs) then
+  set sysname=`/usr/bin/fs sysname | sed "s/^.*'\(.*\)'.*/\1/"`
+else
+  set sysname=x8664_sl7
+endif
 # turn off opengl direct rendering bc problems for nx
 # that problem seems to have been fixed, leave this in here since it
 # took a long time to figure this one out

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -100,8 +100,12 @@ fi
 
 # set afs sysname to replace @sys so links stay functional even if
 # the afs sysname changes in the future
-sysname=`/usr/bin/fs sysname | sed "s/^.*'\(.*\)'.*/\1/"`
-
+if [[ -f /usr/bin/fs ]]
+then
+  sysname=`/usr/bin/fs sysname | sed "s/^.*'\(.*\)'.*/\1/"`
+else
+  sysname=x8664_sl7
+fi
 # turn off opengl direct rendering bc problems for nx
 # that problem seems to have been fixed, leave this in here since it
 # took a long time to figure this one out


### PR DESCRIPTION
Andrea had problems with afs not being installed. This PR checks for /usr/bin/fs before calling it, sets sysname to x8664_sl7 if this is not found