### PR TITLE
Lib64

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -306,19 +306,19 @@ if (! $?PGHOST) then
 endif
 
 # set initial paths, all following get prepended
-set path = (/usr/lib64/qt-3.3/bin /usr/local/bin /usr/bin /usr/local/sbin /usr/sbin)
+set path = (/usr/local/bin /usr/bin /usr/local/sbin /usr/sbin)
 set manpath = `/usr/bin/man --path`
 
 set ldpath = /usr/local/lib64:/usr/lib64
 
 # loop over all bin dirs and prepend to path
-foreach bindir ($COVERITY_ROOT/bin \
+foreach bindir (${COVERITY_ROOT}/bin \
                 ${PARASOFT}/bin \
-                $G4_MAIN/bin \
-                $rootbindir \
-                $OPT_SPHENIX/bin \
-                $OPT_UTILS/bin \
-                $ONLINE_MAIN/bin \
+                ${G4_MAIN}/bin \
+                ${rootbindir} \
+                ${OPT_SPHENIX}/bin \
+                ${OPT_UTILS}/bin \
+                ${ONLINE_MAIN}/bin \
                 ${OFFLINE_MAIN}/bin)
   if (-d $bindir) then
     set path = ($bindir $path)
@@ -330,10 +330,14 @@ foreach libdir (${PARASOFT}/lib \
                 ${OPT_SPHENIX}/lhapdf-5.9.1/lib \
                 ${G4_MAIN}/lib64 \
                 ${rootlibdir} \
-                $OPT_SPHENIX/lib \
-                $OPT_UTILS/lib \
+                ${OPT_SPHENIX}/lib \
+                ${OPT_SPHENIX}/lib64 \
+                ${OPT_UTILS}/lib \
+                ${OPT_UTILS}/lib64 \
                 ${ONLINE_MAIN}/lib \
-                ${OFFLINE_MAIN}/lib)
+                ${ONLINE_MAIN}/lib64 \
+                ${OFFLINE_MAIN}/lib \
+                ${OFFLINE_MAIN}/lib64)
   if (-d $libdir) then
     set ldpath = ${libdir}:${ldpath}
   endif
@@ -344,7 +348,7 @@ foreach mandir (${ROOTSYS}/man \
                 ${OPT_SPHENIX}/share/man \
                 ${OPT_UTILS}/man \
                 ${OPT_UTILS}/share/man \
-                $OFFLINE_MAIN/share/man)
+                ${OFFLINE_MAIN}/share/man)
   if (-d $mandir) then
     set manpath = ${mandir}:${manpath}
   endif

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -170,7 +170,7 @@ then
   then
     export CONFIG_SITE=${OPT_SPHENIX}/etc/config_debug.site
   else
-    if [ -f ${OPT_SPHENIX}/etc/config_debug.site ]
+    if [ -f ${OPT_SPHENIX}/etc/config.site ]
     then
       export CONFIG_SITE=${OPT_SPHENIX}/etc/config.site
     fi
@@ -309,22 +309,9 @@ then
     then
       source ${G4_MAIN}/bin/geant4.sh
     fi
-
-    if [ -d ${G4_MAIN}/bin ]
-    then
-	path=${G4_MAIN}/bin:$path
-    fi
-    if [ -d ${G4_MAIN}/lib64 ] 
-    then
-	ldpath=${G4_MAIN}/lib64:$ldpath
-    fi
-fi
-if [[ -z "$XERCESCROOT" ]]
-then
-  export XERCESCROOT=${G4_MAIN}
 fi
 
-
+# Xerces is installed with G4 (G4 depends on it)
 if [[ -z "$XERCESCROOT" ]]
 then
   export XERCESCROOT=${G4_MAIN}
@@ -370,13 +357,13 @@ manpath=`env PATH=$path /usr/bin/man --path`
 ldpath=/usr/local/lib64:/usr/lib64
 
 #loop over all bin dirs and prepend to path
-for bindir in $COVERITY_ROOT/bin \
+for bindir in ${COVERITY_ROOT}/bin \
               ${PARASOFT}/bin \
-              $G4_MAIN/bin \
-              $rootbindir \
-              $OPT_SPHENIX/bin \
-              $OPT_UTILS/bin \
-              $ONLINE_MAIN/bin \
+              ${G4_MAIN}/bin \
+              ${rootbindir} \
+              ${OPT_SPHENIX}/bin \
+              ${OPT_UTILS}/bin \
+              ${ONLINE_MAIN}/bin \
               ${OFFLINE_MAIN}/bin
 do
   if [ -d $bindir ]
@@ -388,12 +375,17 @@ done
 #loop over all lib dirs and prepend to ldpath
 for libdir in ${PARASOFT}/lib \
                 ${OPT_SPHENIX}/lhapdf-5.9.1/lib \
+                ${G4_MAIN}/lib \
                 ${G4_MAIN}/lib64 \
                 ${rootlibdir} \
-                $OPT_SPHENIX/lib \
-                $OPT_UTILS/lib \
+                ${OPT_SPHENIX}/lib \
+                ${OPT_SPHENIX}/lib64 \
+                ${OPT_UTILS}/lib \
+                ${OPT_UTILS}/lib64 \
                 ${ONLINE_MAIN}/lib \
-                ${OFFLINE_MAIN}/lib
+                ${ONLINE_MAIN}/lib64 \
+                ${OFFLINE_MAIN}/lib \
+                ${OFFLINE_MAIN}/lib64
 do
   if [ -d $libdir ]
   then

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -341,13 +341,13 @@ if [ -z "$COVERITY_ROOT" ]
 then
   export COVERITY_ROOT=/afs/rhic.bnl.gov/app/coverity-2019.03
 fi
-
-if [ -z "$PGHOST" ]
-then
-  export PGHOST=phnxdbrcf2
-  export PGUSER=phnxrc
-  export PG_PHENIX_DBNAME=Phenix_phnxdbrcf2_C
-fi
+# comment out until we have a DB again
+#if [ -z "$PGHOST" ]
+#then
+#  export PGHOST=phnxdbrcf2
+#  export PGUSER=phnxrc
+#  export PG_PHENIX_DBNAME=Phenix_phnxdbrcf2_C
+#fi
 
 path=(/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)
 # we need to use the new PATH here, otherwise when switching between


### PR DESCRIPTION
This PR checks if a lib64 subdir exists and if so adds it to the LD_LIBRARY_PATH. We are getting more and more packages which by default install to lib64 and this is easier than always tweaking them to install under lib. Also remove qt3 from the path in the csh script, comment out setting of PHENIX PGHOST in bash