### PR TITLE
Add pguser

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -300,7 +300,7 @@ endif
 
 #database servers, not used right now
 if (! $?PGHOST) then
-  setenv PGHOST sphenixdbmaster
+  setenv PGHOST sphnxdbmaster
   setenv PGUSER phnxrc
 endif
 

--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -300,9 +300,8 @@ endif
 
 #database servers, not used right now
 if (! $?PGHOST) then
-  setenv PGHOST phnxdbrcf2
+  setenv PGHOST sphenixdbmaster
   setenv PGUSER phnxrc
-  setenv PG_PHENIX_DBNAME Phenix_phnxdbrcf2_C
 endif
 
 # set initial paths, all following get prepended

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -345,7 +345,7 @@ fi
 # point to scratch DB
 if [ -z "$PGHOST" ]
 then
-  export PGHOST=sphenixdbmaster
+  export PGHOST=sphnxdbmaster
   export PGUSER=phnxrc
 fi
 

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -341,13 +341,13 @@ if [ -z "$COVERITY_ROOT" ]
 then
   export COVERITY_ROOT=/afs/rhic.bnl.gov/app/coverity-2019.03
 fi
-# comment out until we have a DB again
-#if [ -z "$PGHOST" ]
-#then
-#  export PGHOST=phnxdbrcf2
-#  export PGUSER=phnxrc
-#  export PG_PHENIX_DBNAME=Phenix_phnxdbrcf2_C
-#fi
+
+# point to scratch DB
+if [ -z "$PGHOST" ]
+then
+  export PGHOST=sphenixdbmaster
+  export PGUSER=phnxrc
+fi
 
 path=(/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)
 # we need to use the new PATH here, otherwise when switching between


### PR DESCRIPTION
This PR puts the PGUSER env var back. It is needed so we can access our DBs without adding a user name to the connection string. The PGHOST is now set to sphnxdbmaster