### PR TITLE
Add lib64 of local install to LD_LIBRARY_PATH

### DIFF
--- a/bin/setup_local.csh
+++ b/bin/setup_local.csh
@@ -6,26 +6,33 @@ if (! $?OPT_SPHENIX) then
 endif
 if ($#argv > 0) then
   source ${OPT_SPHENIX}/bin/setup_root6_include_path.csh $*
-  set ldpath = ""
-  set bpath = ""
-  set first=1
+  set local_ldpath = ""
+  set local_bpath = ""
+  set local_first=1
   foreach arg ($*)
-    set libpath = $arg/lib
-    set binpath = $arg/bin
-    if (-d $libpath) then
-      if ($first == 1) then
-        set ldpath = $libpath
-        set first=0
-      else
-        set ldpath =  ${ldpath}:${libpath}
+    foreach local_libpath ( $arg/lib $arg/lib64)
+      if (-d $local_libpath) then
+        if ($local_first == 1) then
+          set local_ldpath = $local_libpath
+          set local_first=0
+        else
+          set local_ldpath =  ${local_ldpath}:${local_libpath}
+        endif
       endif
-    endif
+    end
+    set binpath = $arg/bin
     if (-d $binpath) then
-      set bpath=($bpath $binpath)
+      set local_bpath=($local_bpath $binpath)
     endif
   end
-setenv LD_LIBRARY_PATH ${ldpath}:$LD_LIBRARY_PATH
-set path = ($bpath $path)
+  setenv LD_LIBRARY_PATH ${local_ldpath}:$LD_LIBRARY_PATH
+  set path = ($local_bpath $path)
+  echo LD_LIBRARY_PATH now $LD_LIBRARY_PATH
+  echo path now $path
+#unset locally used variables
+  unset local_binpath
+  unset local_bpath
+  unset local_first
+  unset local_ldpath
+  unset local_libpath
 endif  
-echo LD_LIBRARY_PATH now $LD_LIBRARY_PATH
-echo path now $path

--- a/bin/setup_local.sh
+++ b/bin/setup_local.sh
@@ -14,18 +14,20 @@ then
   source ${OPT_SPHENIX}/bin/setup_root6_include_path.sh $@
   for arg in "$@"
   do
-    local_libpath=$arg/lib
-    local_binpath=$arg/bin
-    if [ -d $local_libpath ]
-    then
-      if [ $local_firsta == 1 ]
+    for local_libpath in $arg/lib $arg/lib64
+    do
+      if [ -d $local_libpath ]
       then
-        local_ldpath=$local_libpath
-        local_firsta=0
-      else
-        local_ldpath=${local_ldpath}:${local_libpath}
+        if [ $local_firsta == 1 ]
+        then
+          local_ldpath=$local_libpath
+          local_firsta=0
+        else
+          local_ldpath=${local_ldpath}:${local_libpath}
+        fi
       fi
-    fi
+    done
+    local_binpath=$arg/bin
     if [ -d $local_binpath ]
     then
       if [ $local_firstb == 1 ]


### PR DESCRIPTION
When allowing libraries to be installed in /lib64 I forgot to add this to the setup_local scripts, so local installations only added /lib to the LD_LIBRARY_PATH. Now it also adds /lib64 if it exists