### PR TITLE
Add local lib64 gcc 8.3

### DIFF
--- a/etc/config.site
+++ b/etc/config.site
@@ -1,4 +1,4 @@
-# enable c++11 flag by default
-CXXFLAGS="-g -O2 -std=c++11"
+# enable c++17 flag by default
+CXXFLAGS="-g -O2 -std=c++17"
 # Allow LD_LIBRARY_PATH to override RPATH
 LDFLAGS='-Wl,--enable-new-dtags'

--- a/etc/config_debug.site
+++ b/etc/config_debug.site
@@ -1,4 +1,4 @@
-# enable c++11 flag by default
-CXXFLAGS="-g -std=c++11"
+# enable c++17 flag by default
+CXXFLAGS="-g -std=c++17"
 # Allow LD_LIBRARY_PATH to override RPATH
 LDFLAGS='-Wl,--enable-new-dtags'


### PR DESCRIPTION
When allowing packages to install libraries into /lib64 I forgot to update the setup_local scripts accordingly which up to now only added /lib to the LD_LIBRARY_PATH. Now also install/lib64 is added if it exists