### PR TITLE
append rootmacros to ROOT_INCLUDE_PATH

### DIFF
--- a/bin/setup_root6_include_path.csh
+++ b/bin/setup_root6_include_path.csh
@@ -1,24 +1,24 @@
 #! /bin/csh -f -x
 unsetenv ROOT_INCLUDE_PATH
 setenv EVT_LIB $ROOTSYS/lib
-set first=1
-set offline_main_done=0
+set local_first=1
+set local_offline_main_done=0
 # make sure our include dirs come first in ROOT_INCLUDE_PATH, 
 # use OFFLINE_MAIN only if it comes in the list of arguments, flag it as used
 if ($#argv > 0) then
   foreach arg ($*)
     if ($arg =~ *"$OFFLINE_MAIN"*) then
-      set offline_main_done=1
+      set local_offline_main_done=1
     endif
     if (-d $arg) then
-      foreach incdir (`find $arg/include -maxdepth 1 -type d -print`)
-        if (-d $incdir) then
-          if ($first == 1) then
-            setenv ROOT_INCLUDE_PATH $incdir
-            set first=0
+      foreach local_incdir (`find $arg/include -maxdepth 1 -type d -print`)
+        if (-d $local_incdir) then
+          if ($local_first == 1) then
+            setenv ROOT_INCLUDE_PATH $local_incdir
+            set local_first=0
           else
-            if ($incdir !~ {*CGAL} && $incdir !~ {*Vc} && $incdir !~ {*rave}) then
-              setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+            if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
+              setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
             endif
           endif
         endif
@@ -27,20 +27,27 @@ if ($#argv > 0) then
   end
 endif  
 # add OFFLINE_MAIN include paths by default if not already done
-if ($offline_main_done == 0) then
-  if ($first == 1) then
+if ($local_offline_main_done == 0) then
+  if ($local_first == 1) then
     setenv ROOT_INCLUDE_PATH $OFFLINE_MAIN/include
   else
     setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include
   endif
-  foreach incdir (`find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`)
-    if (-d $incdir) then
-      if ($incdir !~ {*CGAL} && $incdir !~ {*Vc} && $incdir !~ {*rave}) then
-        setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$incdir
+  foreach local_incdir (`find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`)
+    if (-d $local_incdir) then
+      if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
+        setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
       endif
     endif
   end
 endif
 # add G4 include path
 setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$G4_MAIN/include
+# add ROOT Macros
+if (-d $OFFLINE_MAIN/rootmacros) then
+  setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/rootmacros
+endif
 #echo $ROOT_INCLUDE_PATH
+unset local_first
+unset local_incdir
+unset local_offline_main_done

--- a/bin/setup_root6_include_path.sh
+++ b/bin/setup_root6_include_path.sh
@@ -55,8 +55,13 @@ then
     fi
   done
 fi
-ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$G4_MAIN/include
 # add G4 include path
+ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$G4_MAIN/include
+# add ROOT Macros
+if [ -d $OFFLINE_MAIN/rootmacros ]
+then
+  ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$OFFLINE_MAIN/rootmacros
+fi
 export ROOT_INCLUDE_PATH
 #unset locally used variables
 unset local_first


### PR DESCRIPTION
This PR appends the install location of the common root macros ($OFFLINE_MAIN/rootmacros) to the ROOT_INCLUDE_PATH. Our new Fun4All_G4_XXX.C and G4Setup_XXX.C macros which describe a specific detector pick them up from there. If one has a local copy it overrides that (that needs to be checked). This change does not interfere with the old macros