### PR TITLE
replace hardcoded sysname in path

### DIFF
--- a/bin/step-gdml.sh
+++ b/bin/step-gdml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # this script sets up the LD_LIBRARY_PATH and then runs step-gdml
-# which is installed under /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/step-gdml
+# which is installed under $OPT_SPHENIX/opt/sphenix/core/step-gdml
 export LD_LIBRARY_PATH=$OPT_SPHENIX/opencascade-7.3.0/lib:$LD_LIBRARY_PATH
 #echo $LD_LIBRARY_PATH
-export PATH=/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/step-gdml/bin:$PATH
+export PATH=$OPT_SPHENIX/step-gdml/bin:$PATH
 step-gdml


### PR DESCRIPTION
This PR uses $OPT_SPHENIX instead of hardcoded /cvmfs/... so this script does not have to be adjusted when copying to other cvmfs volumes (or systems)