### PR TITLE
Root6 incpath

### DIFF
--- a/bin/setup_root6_include_path.csh
+++ b/bin/setup_root6_include_path.csh
@@ -14,9 +14,9 @@ if ($#argv > 0) then
     if (-d $arg) then
       foreach local_incdir (`find $arg/include -maxdepth 1 -type d -print`)
         if (-d $local_incdir) then
-            if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
-              setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
-            endif
+          if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
+            setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
+          endif
         endif
       end
     endif

--- a/bin/setup_root6_include_path.csh
+++ b/bin/setup_root6_include_path.csh
@@ -1,7 +1,8 @@
 #! /bin/csh -f -x
 unsetenv ROOT_INCLUDE_PATH
 setenv EVT_LIB $ROOTSYS/lib
-set local_first=1
+# start with your local directory
+setenv ROOT_INCLUDE_PATH ./
 set local_offline_main_done=0
 # make sure our include dirs come first in ROOT_INCLUDE_PATH, 
 # use OFFLINE_MAIN only if it comes in the list of arguments, flag it as used
@@ -13,14 +14,9 @@ if ($#argv > 0) then
     if (-d $arg) then
       foreach local_incdir (`find $arg/include -maxdepth 1 -type d -print`)
         if (-d $local_incdir) then
-          if ($local_first == 1) then
-            setenv ROOT_INCLUDE_PATH $local_incdir
-            set local_first=0
-          else
             if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
               setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
             endif
-          endif
         endif
       end
     endif
@@ -28,11 +24,7 @@ if ($#argv > 0) then
 endif  
 # add OFFLINE_MAIN include paths by default if not already done
 if ($local_offline_main_done == 0) then
-  if ($local_first == 1) then
-    setenv ROOT_INCLUDE_PATH $OFFLINE_MAIN/include
-  else
     setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/include
-  endif
   foreach local_incdir (`find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`)
     if (-d $local_incdir) then
       if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
@@ -48,6 +40,5 @@ if (-d $OFFLINE_MAIN/rootmacros) then
   setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$OFFLINE_MAIN/rootmacros
 endif
 #echo $ROOT_INCLUDE_PATH
-unset local_first
 unset local_incdir
 unset local_offline_main_done

--- a/bin/setup_root6_include_path.sh
+++ b/bin/setup_root6_include_path.sh
@@ -21,11 +21,11 @@ then
       do
         if [ -d $local_incdir ]
         then
-            if [[ $local_incdir != *"CGAL"* && $local_incdir != *"Vc"* && $local_incdir != *"rave"* ]]
-            then
-              ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$local_incdir
-            fi
+          if [[ $local_incdir != *"CGAL"* && $local_incdir != *"Vc"* && $local_incdir != *"rave"* ]]
+          then
+            ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$local_incdir
           fi
+        fi
       done
     fi
   done

--- a/bin/setup_root6_include_path.sh
+++ b/bin/setup_root6_include_path.sh
@@ -3,7 +3,7 @@
 # user variables
 unset ROOT_INCLUDE_PATH
 export EVT_LIB=$ROOTSYS/lib
-local_first=1
+ROOT_INCLUDE_PATH=./
 local_offline_main_done=0
 # make sure our include dirs come first in ROOT_INCLUDE_PATH
 # use OFFLINE_MAIN only if it comes in the list of arguments, flag it as used
@@ -21,29 +21,18 @@ then
       do
         if [ -d $local_incdir ]
         then
-          if [ $local_first == 1 ]
-          then
-            ROOT_INCLUDE_PATH=$local_incdir
-            local_first=0
-          else
             if [[ $local_incdir != *"CGAL"* && $local_incdir != *"Vc"* && $local_incdir != *"rave"* ]]
             then
               ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$local_incdir
             fi
           fi
-        fi
       done
     fi
   done
 fi 
 if [ $local_offline_main_done == 0 ]
 then
-  if [ $local_first == 1 ]
-  then
-    ROOT_INCLUDE_PATH=$OFFLINE_MAIN/include
-  else
     ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$OFFLINE_MAIN/include
-  fi
   for local_incdir in `find $OFFLINE_MAIN/include -maxdepth 1 -type d -print`
   do
     if [ -d $local_incdir ]
@@ -64,7 +53,6 @@ then
 fi
 export ROOT_INCLUDE_PATH
 #unset locally used variables
-unset local_first
 unset local_incdir
 unset local_offline_main_done
 #echo $ROOT_INCLUDE_PATH


### PR DESCRIPTION
This PR adds ./ to the beginning of the ROOT_INCLUDE_PATH to pick up local includes first This is needed that local macros are consistently favored over the centrally installed ones (needs a macro change include "" --> include <> which will come next)