### PR TITLE
unsetting CXX etc kills cmake

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -410,12 +410,6 @@ source ${OPT_SPHENIX}/bin/setup_root6_include_path.csh $OFFLINE_MAIN
 # set up gcc 8.3 is installed (if this exists we are in the gcc 8.3 area
 if (-f  ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh) then
   source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh
-# unset these variables which we do not want
-# (they interfere with e.g. ccache)
-  unsetenv FC
-  unsetenv CC
-  unsetenv CXX
-  unsetenv COMPILER_PATH
 endif
 
 #unset local variables

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -485,10 +485,4 @@ source $OPT_SPHENIX/bin/setup_root6_include_path.sh $OFFLINE_MAIN
 if [[ -f ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh ]]
 then
   source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh
-# unset these variables which we do not want
-# (they interfere with e.g. ccache)
-  unset FC
-  unset CC
-  unset CXX
-  unset COMPILER_PATH
 fi


### PR DESCRIPTION
This PR reverses a previous one. It turns out that cmake looks at CXX , CC and so on. Removing these env vars leaves cmake choosing the SL7 stock compiler gcc 4.8