### PR TITLE
upgrade to insure 7.5.5

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -303,7 +303,7 @@ endif
 
 # Set up Insure++, if we have it
 if (! $?PARASOFT) then
-  setenv PARASOFT /afs/rhic.bnl.gov/app/insure-7.5.3
+  setenv PARASOFT /afs/rhic.bnl.gov/app/insure-7.5.5
 endif
 
 # Coverity

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -357,7 +357,7 @@ fi
 # Set up Insure++, if we have it
 if [ -z  "$PARASOFT" ] 
 then
-  export PARASOFT=/afs/rhic.bnl.gov/app/insure-7.5.3
+  export PARASOFT=/afs/rhic.bnl.gov/app/insure-7.5.5
 fi
 
 # Coverity


### PR DESCRIPTION
This PR sets PARASOFT to /afs/rhic.bnl.gov/app/insure-7.5.5
