### PR TITLE
S3read

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -418,13 +418,12 @@ if (-f  ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh) then
 endif
 
 # check if the s3 read only access is setup, otherwise add it
-if grep -q eicS3read "$HOME/.mcs3/config.json"; then
-  #endpoint already configured, do nothing. 
-  #Bash needs something here, otherwise throws an error
-  echo ""
+if ( { grep -q 'eicS3read' $HOME/.mcs3/config.json } ) then
+  #do nothing since already configured
 else
-   mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
-fi
+  #add the alias
+  mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
+endif
 
 #unset local variables
 unset local_cvmfsvolume

--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -417,5 +417,14 @@ if (-f  ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh) then
   source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh
 endif
 
+# check if the s3 read only access is setup, otherwise add it
+if grep -q eicS3read "$HOME/.mcs3/config.json"; then
+  #endpoint already configured, do nothing. 
+  #Bash needs something here, otherwise throws an error
+  echo ""
+else
+   mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
+fi
+
 #unset local variables
 unset local_cvmfsvolume

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -489,12 +489,9 @@ export MANPATH
 source $OPT_SPHENIX/bin/setup_root6_include_path.sh $OFFLINE_MAIN
 
 # check if the s3 read only access is setup, otherwise add it
-if ( { grep -q 'eicS3read' $HOME/.mcs3/config.json } ) then
-  #do nothing since already configured
-else
-  #add the alias
-  mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
-endif
+if ! grep -q eicS3read "$HOME/.mcs3/config.json"; then
+   mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
+fi
 
 # setup gcc 8.301 (copied from /cvmfs/sft.cern.ch/lcg/releases)
 if [[ -f ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh ]]

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -488,6 +488,14 @@ export LD_LIBRARY_PATH
 export MANPATH
 source $OPT_SPHENIX/bin/setup_root6_include_path.sh $OFFLINE_MAIN
 
+# check if the s3 read only access is setup, otherwise add it
+if ( { grep -q 'eicS3read' $HOME/.mcs3/config.json } ) then
+  #do nothing since already configured
+else
+  #add the alias
+  mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
+endif
+
 # setup gcc 8.301 (copied from /cvmfs/sft.cern.ch/lcg/releases)
 if [[ -f ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh ]]
 then


### PR DESCRIPTION
Updates the setup script to check for S3 read access account setup:

If the endpoint has already been configured, does nothing
If it doesn't, configures the endpoint with the alias `eicS3` such that users can then access S3 via something like:

`mcs3 ls eicS3/eic/blahblah`

There was apparently also some commits that were not updated in the gcc8-3 branch that are included here.