### PR TITLE
remove printout which will kill winsshfs at BNL

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -419,11 +419,11 @@ if (-f  ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh) then
 endif
 
 # check if the s3 read only access is setup, otherwise add it
-if ( { grep -q 'eicS3read' $HOME/.mcs3/config.json } ) then
+if ( -d $HOME/.mcs3 && { grep -q 'eicS3read' $HOME/.mcs3/config.json } ) then
   #do nothing since already configured
 else
   #add the alias
-  mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
+  mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read >& /dev/null
 endif
 
 #unset local variables

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -489,8 +489,8 @@ export MANPATH
 source $OPT_SPHENIX/bin/setup_root6_include_path.sh $OFFLINE_MAIN
 
 # check if the s3 read only access is setup, otherwise add it
-if ! grep -q eicS3read "$HOME/.mcs3/config.json"; then
-   mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read
+if [ ! -d $HOME/.mcs3 ] ||  ! grep -q eicS3read "$HOME/.mcs3/config.json" ; then
+   mcs3 config host add eicS3 https://dtn01.sdcc.bnl.gov:9000/ eicS3read eicS3read &> /dev/null
 fi
 
 # setup gcc 8.301 (copied from /cvmfs/sft.cern.ch/lcg/releases)


### PR DESCRIPTION
This PR fixes a serious problem in the setup scripts. They are under no circumstances to print out anything. The addition of the one time S3 setup resulted in blurbs coming out of setting it up. After fixing this (pipe to /dev/null as recommended) doing a grep in a non existing directory spat some more characters on the screen. The new version checks for the directory before it does grep. 