### PR TITLE
remove DCACHE from GSEARCHPATH, keep XROOTD for sh, MINIO for tcsh

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -322,7 +322,7 @@ endif
 
 # File catalog search path
 if (! $?GSEARCHPATH) then
-    setenv GSEARCHPATH .:PG:XROOTD:DCACHE:MINIO
+    setenv GSEARCHPATH .:PG:MINIO
 endif
 
 # set initial paths, all following get prepended

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -380,7 +380,7 @@ fi
 # File catalog search path
 if [ -z "$GSEARCHPATH" ]
 then
-  export GSEARCHPATH=.:PG:XROOTD:DCACHE:MINIO
+  export GSEARCHPATH=.:PG:XROOTD
 fi
 
 path=(/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)


### PR DESCRIPTION
This PR fixes the GSEARCHPATH. Only sphenix accounts with the sphenix gid can access lustre via xrootd, phenix accounts with sphenix as secondary gid use minio