### PR TITLE
switch all to xrootd with minio as last option

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -322,7 +322,7 @@ endif
 
 # File catalog search path
 if (! $?GSEARCHPATH) then
-    setenv GSEARCHPATH .:PG:MINIO
+    setenv GSEARCHPATH .:PG:XROOTD:MINIO
 endif
 
 # set initial paths, all following get prepended

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -380,7 +380,7 @@ fi
 # File catalog search path
 if [ -z "$GSEARCHPATH" ]
 then
-  export GSEARCHPATH=.:PG:XROOTD
+  export GSEARCHPATH=.:PG:XROOTD:MINIO
 fi
 
 path=(/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)


### PR DESCRIPTION
New approach - now using keytab to authenticate to xrootd for all accounts. Use xrootd by default, leave minio as last option even though it is not used in that position