### PR TITLE
Add json file for writing to sPHENIX CDB

### DIFF
--- a/etc/sPHENIX_cdb_write.json
+++ b/etc/sPHENIX_cdb_write.json
@@ -1,0 +1,11 @@
+{
+  "host":    "nopayloaddb-nopayloaddb.apps.rcf.bnl.gov",
+  "port":    "80",
+  "apiroot": "/api/cdb_rest",
+  "apiver":  "",
+  "path":    "/gpfs02/cvmfst0/sphenix.sdcc.bnl.gov/cdb/test",
+  "use_cache": true,
+  "verbosity": 0,
+  "retry_times": 5,
+  "retry_max_delay": 60
+}


### PR DESCRIPTION
This PR adds the json config to write to the sPHENIX conditions DB and read back immediately