### PR TITLE
old leftover - remove gloo from ROOT_INCLUDE_PATH, it contains system includes from pytorch

### DIFF
--- a/bin/setup_root6_include_path.csh
+++ b/bin/setup_root6_include_path.csh
@@ -14,7 +14,7 @@ if ($#argv > 0) then
     if (-d $arg) then
       foreach local_incdir (`find $arg/include -maxdepth 1 -type d -print`)
         if (-d $local_incdir) then
-          if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave}) then
+          if ($local_incdir !~ {*CGAL} && $local_incdir !~ {*Vc} && $local_incdir !~ {*rave} && $local_incdir !~ {*gloo} ) then
             setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
           endif
         endif

--- a/bin/setup_root6_include_path.sh
+++ b/bin/setup_root6_include_path.sh
@@ -21,7 +21,7 @@ then
       do
         if [ -d $local_incdir ]
         then
-          if [[ $local_incdir != *"CGAL"* && $local_incdir != *"Vc"* && $local_incdir != *"rave"* ]]
+          if [[ $local_incdir != *"CGAL"* && $local_incdir != *"Vc"* && $local_incdir != *"rave"* && $local_incdir != *"gloo"* ]]
           then
             ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$local_incdir
           fi


### PR DESCRIPTION
This PR removed $OFFLINE_MAIN/include/gloo from the ROOT_INCLUDE_PATH. It is installed by copying pytorch and it contains linux system include overrides which if root picks them up will cause problems