### PR TITLE
clang needs gcc 8.3 so far

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -152,7 +152,7 @@ endif
 
 # set site wide compiler options (no rpath hardcoding)
 if (! $?CONFIG_SITE) then
-  if ($opt_v =~ "debug" ) then
+  if ($opt_v =~ "debug*" ) then
     if (-f ${OPT_SPHENIX}/etc/config_debug.site) then
       setenv CONFIG_SITE ${OPT_SPHENIX}/etc/config_debug.site
     endif
@@ -413,12 +413,15 @@ setenv MANPATH `echo -n $MANPATH | sed 's/.$//'`
 #set ROOT_INCLUDE_PATH for root6
 source ${OPT_SPHENIX}/bin/setup_root6_include_path.csh $OFFLINE_MAIN
 
-# set up gcc 8.3 is installed (if this exists we are in the gcc 8.3 area
-if (-f  ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh) then
-  source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh
-endif
-if (-f  ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.csh) then
-  source ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.csh
+# use gcc 8.3 for clang builds
+if ($opt_v =~ "clang*" ) then
+  if (-f  ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh) then
+    source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.csh
+  endif
+else
+  if (-f  ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.csh) then
+    source ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.csh
+  endif
 endif
 
 # we need to execute our python3 in our path to get the version

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -197,7 +197,7 @@ fi
 # set site wide compiler options (no rpath hardcoding)
 if [[ -z "$CONFIG_SITE" ]]
 then
-  if [[ $opt_v = "debug" && -f ${OPT_SPHENIX}/etc/config_debug.site ]]
+  if [[ $opt_v = "debug"* && -f ${OPT_SPHENIX}/etc/config_debug.site ]]
   then
     export CONFIG_SITE=${OPT_SPHENIX}/etc/config_debug.site
   else
@@ -494,14 +494,18 @@ export LD_LIBRARY_PATH
 export MANPATH
 source $OPT_SPHENIX/bin/setup_root6_include_path.sh $OFFLINE_MAIN
 
-# setup gcc 8.301 (copied from /cvmfs/sft.cern.ch/lcg/releases)
-if [[ -f ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh ]]
+# use gcc 8.3 for clang builds
+if [[ $opt_v = "clang"* ]]
 then
-  source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh
-fi
-if [[ -f ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.sh ]]
-then
-  source ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.sh
+  if [[ -f ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh ]]
+  then
+    source ${OPT_SPHENIX}/gcc/8.3.0.1-0a5ad/x86_64-centos7/setup.sh
+  fi
+else
+  if [[ -f ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.sh ]]
+  then
+    source ${OPT_SPHENIX}/gcc/12.1.0-57c96/x86_64-centos7/setup.sh
+  fi
 fi
 
 # we need to execute our python3 in our path to get the version


### PR DESCRIPTION
clang needs gcc 8.3, llvm does not build with gcc 12 so far