### PR TITLE
set up LHAPDF

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -176,6 +176,7 @@ if (! $?PERL5LIB) then
    endif
 endif
 
+#lhapdf 5
 if (! $?LHAPATH) then
   setenv LHAPATH ${OPT_SPHENIX}/lhapdf-5.9.1/share/lhapdf/PDFsets
 endif
@@ -250,7 +251,24 @@ endif
 
 #add our python packages and path to ROOT.py
 if (! $?PYTHONPATH) then
-  setenv PYTHONPATH ${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages:${ROOTSYS}/lib
+  setenv PYTHONPATH ${ROOTSYS}/lib
+  if (-d ${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages) then
+    setenv PYTHONPATH ${PYTHONPATH}:${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages
+  endif
+  if (-d ${OFFLINE_MAIN}/lib/python3.8/site-packages) then
+    setenv PYTHONPATH ${PYTHONPATH}:${OFFLINE_MAIN}/lib/python3.8/site-packages
+  endif
+endif
+
+#LHAPDF 6
+if (! $?LHAPDF_DATA_PATH) then
+  if (-d ${OFFLINE_MAIN}/share/LHAPDF) then
+    setenv LHAPDF_DATA_PATH ${OFFLINE_MAIN}/share/LHAPDF
+  else
+    if (-d ${OPT_SPHENIX}/LHAPDF/share/LHAPDF) then
+      setenv LHAPDF_DATA_PATH ${OPT_SPHENIX}/LHAPDF/share/LHAPDF
+    endif
+  endif
 endif
 
 # Add Geant4

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -310,9 +310,31 @@ then
   fi
 fi
 
-if [[ -z "$PYTHONPATH" && -d ${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages ]]
+#LHAPDF 6
+if [[ -z $LHAPDF_DATA_PATH ]]
 then
-  export PYTHONPATH=${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages:${ROOTSYS}/lib
+  if [[ -d ${OFFLINE_MAIN}/share/LHAPDF ]]
+  then
+    export LHAPDF_DATA_PATH=${OFFLINE_MAIN}/share/LHAPDF
+  else
+    if [[ -d ${OPT_SPHENIX}/LHAPDF/share/LHAPDF ]]
+    then
+      export LHAPDF_DATA_PATH=${OPT_SPHENIX}/LHAPDF/share/LHAPDF
+    fi
+  fi
+fi
+
+if [[ -z "$PYTHONPATH" ]]
+then
+  export PYTHONPATH=${ROOTSYS}/lib
+  if [[ -d ${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages ]]
+  then
+    export PYTHONPATH=${PYTHONPATH}:${OPT_SPHENIX}/pythonpackages/lib/python3.8/site-packages
+  fi
+  if [[ -d ${OFFLINE_MAIN}/lib/python3.8/site-packages ]]
+  then
+    export PYTHONPATH=${PYTHONPATH}:${OFFLINE_MAIN}/lib/python3.8/site-packages
+  fi
 fi
 
 # Add Geant4


### PR DESCRIPTION
This PR adds the pdf path for LHAPDF 6 and adds it to the PYTHONPATH. This should finally enable us to run the lhapdf python script to fetch pdfs 