### PR TITLE
move cdb files from cdbtest to cdb

### DIFF
--- a/etc/sPHENIX_newcdb.json
+++ b/etc/sPHENIX_newcdb.json
@@ -1,8 +1,8 @@
 {
   "base_url": "helm-test1.apps.rcf.bnl.gov",
   "api_res":  "/api/cdb_rest/",
-  "write_dir": "/sphenix/cvmfscalib/sphnxpro/cdbtest/",
-  "read_dir_list": ["/cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdbtest/", "/sphenix/cvmfscalib/sphnxpro/cdbtest/"],
+  "write_dir": "/sphenix/cvmfscalib/sphnxpro/cdb/",
+  "read_dir_list": ["/cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdb/", "/sphenix/cvmfscalib/sphnxpro/cdb/"],
   "n_retries": 5,
   "print_time_stamps": false,
   "cache_life_time": 10,


### PR DESCRIPTION
This PR moves the cdb to it's final location (/cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdb)