### PR TITLE
use new server

### DIFF
--- a/etc/sPHENIX_newcdb.json
+++ b/etc/sPHENIX_newcdb.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "helm-test1.apps.rcf.bnl.gov",
+  "base_url": "nopayloaddb.apps.rcf.bnl.gov",
   "api_res":  "/api/cdb_rest/",
   "write_dir": "/sphenix/cvmfscalib/sphnxpro/cdb/",
   "read_dir_list": ["/cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdb/", "/sphenix/cvmfscalib/sphnxpro/cdb/"],


### PR DESCRIPTION
This PR tries this again - update only sPHENIX_newcdb.json with the new server, leave old files intact for legacy use