### PR TITLE
unset CPLUS_INCLUDE_PATH with -n, bad behavior if set, remove obsolete coverity

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -66,7 +66,7 @@ if ($opt_n) then
   unsetenv CERN*
   unsetenv CALIBRATIONROOT
   unsetenv CONFIG_SITE
-  unsetenv COVERITY_ROOT
+  unsetenv CPLUS_INCLUDE_PATH
   unsetenv CVSROOT
   unsetenv G4*
   unsetenv GSEARCHPATH
@@ -334,11 +334,6 @@ if (! $?PARASOFT) then
   setenv PARASOFT /afs/rhic.bnl.gov/app/insure-7.5.5
 endif
 
-# Coverity
-if (! $?COVERITY_ROOT) then
-  setenv COVERITY_ROOT /afs/rhic.bnl.gov/app/coverity-2021.12
-endif
-
 # File catalog search path
 if (! $?GSEARCHPATH) then
     setenv GSEARCHPATH .:PG:LUSTRE:XROOTD:MINIO
@@ -351,8 +346,7 @@ set manpath = `/usr/bin/man --path`
 set ldpath = /usr/local/lib64:/usr/lib64
 
 # loop over all bin dirs and prepend to path
-foreach bindir (${COVERITY_ROOT}/bin \
-                ${PARASOFT}/bin \
+foreach bindir (${PARASOFT}/bin \
                 ${G4_MAIN}/bin \
                 ${rootbindir} \
                 ${OPT_SPHENIX}/bin \

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -81,6 +81,7 @@ if [ $opt_n != 0 ]
   unset ${!CERN*}
   unset CALIBRATIONROOT
   unset CONFIG_SITE
+  unset CPLUS_INCLUDE_PATH
   unset CVSROOT
   unset ${!G4*}
   unset GSEARCHPATH
@@ -399,12 +400,6 @@ then
   export PARASOFT=/afs/rhic.bnl.gov/app/insure-7.5.5
 fi
 
-# Coverity
-if [ -z "$COVERITY_ROOT" ]
-then
-  export COVERITY_ROOT=/afs/rhic.bnl.gov/app/coverity-2021.12
-fi
-
 # File catalog search path
 if [ -z "$GSEARCHPATH" ]
 then
@@ -419,8 +414,7 @@ manpath=`env PATH=$path /usr/bin/man --path`
 ldpath=/usr/local/lib64:/usr/lib64
 
 #loop over all bin dirs and prepend to path
-for bindir in ${COVERITY_ROOT}/bin \
-              ${PARASOFT}/bin \
+for bindir in ${PARASOFT}/bin \
               ${G4_MAIN}/bin \
               ${rootbindir} \
               ${OPT_SPHENIX}/bin \


### PR DESCRIPTION
if CPLUS_INCLUDE_PATH is set it creates a subtle change in the include path order which wreak havoc in our build but is very hard to find. We do not use this but other packages might do. This pre-emptively unsets it when sourced with -n