### PR TITLE
unset CPLUS_INCLUDE_PATH when using -n

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -66,7 +66,7 @@ if ($opt_n) then
   unsetenv CERN*
   unsetenv CALIBRATIONROOT
   unsetenv CONFIG_SITE
-  unsetenv COVERITY_ROOT
+  unsetenv CPLUS_INCLUDE_PATH
   unsetenv CVSROOT
   unsetenv G4*
   unsetenv GSEARCHPATH

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -81,6 +81,7 @@ if [ $opt_n != 0 ]
   unset ${!CERN*}
   unset CALIBRATIONROOT
   unset CONFIG_SITE
+  unset CPLUS_INCLUDE_PATH
   unset CVSROOT
   unset ${!G4*}
   unset GSEARCHPATH


### PR DESCRIPTION
Same as master - unset CPLUS_INCLUDE_PATH if sourced with -n since this can wreak hard to debug havoc in our include path ordering
