### PR TITLE
set default build to ana

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -23,7 +23,7 @@ limit coredumpsize 0
 set opt_a = 0
 set opt_b = 0
 set opt_n = 0
-set opt_v = "new"
+set opt_v = "ana"
 
 foreach arg ($*)
     switch ($arg)

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -28,7 +28,7 @@ ulimit -c 0
 
 opt_a=0
 opt_n=0
-opt_v="new"
+opt_v="ana"
 opt_b="none"
 
 this_script=$BASH_SOURCE


### PR DESCRIPTION
This PR changes the default build from new to ana to avoid old sessions locking outdated files in cvmfs