### PR TITLE
source rucio setup script from sphenix setup script

### DIFF
--- a/bin/sphenix_setup.csh
+++ b/bin/sphenix_setup.csh
@@ -461,5 +461,9 @@ if (-f /sphenix/user/local_setup_scripts/bin/mc_host_sphenixS3.csh) then
   source /sphenix/user/local_setup_scripts/bin/mc_host_sphenixS3.csh
 endif
 
+if (-f /cvmfs/sphenix.sdcc.bnl.gov/rucio-clients/setup.csh) then
+  source /cvmfs/sphenix.sdcc.bnl.gov/rucio-clients/setup.csh
+endif
+
 #unset local variables
 unset local_cvmfsvolume

--- a/bin/sphenix_setup.sh
+++ b/bin/sphenix_setup.sh
@@ -546,3 +546,6 @@ if [[ -f /sphenix/user/local_setup_scripts/bin/mc_host_sphenixS3.sh ]]
 then
   source /sphenix/user/local_setup_scripts/bin/mc_host_sphenixS3.sh
 fi
+
+# set up rucio
+[[ -f /cvmfs/sphenix.sdcc.bnl.gov/rucio-clients/setup.sh ]] && source /cvmfs/sphenix.sdcc.bnl.gov/rucio-clients/setup.sh


### PR DESCRIPTION
This PR sources the rucio setup script from our /cvmfs/sphenix.sdcc.bnl.gov/rucio-clients area if it exists