### PR TITLE
protect against missing subdirs in install area messing up paths in setup_local scripts

### DIFF
--- a/bin/setup_local.csh
+++ b/bin/setup_local.csh
@@ -25,7 +25,9 @@ if ($#argv > 0) then
       set local_bpath=($local_bpath $binpath)
     endif
   end
-  setenv LD_LIBRARY_PATH ${local_ldpath}:$LD_LIBRARY_PATH
+  if ($local_ldpath != "") then
+    setenv LD_LIBRARY_PATH ${local_ldpath}:$LD_LIBRARY_PATH
+  endif
   set path = ($local_bpath $path)
   echo LD_LIBRARY_PATH now $LD_LIBRARY_PATH
   echo path now $path

--- a/bin/setup_local.sh
+++ b/bin/setup_local.sh
@@ -39,8 +39,8 @@ then
       fi
     fi
   done
-  export LD_LIBRARY_PATH=${local_ldpath}:$LD_LIBRARY_PATH
-  export PATH=${local_bpath}:${PATH}
+  [ ! -z "$local_ldpath" ] && export LD_LIBRARY_PATH=${local_ldpath}:$LD_LIBRARY_PATH
+  [ ! -z "$local_bpath" ] && export PATH=${local_bpath}:$PATH
   echo LD_LIBRARY_PATH now $LD_LIBRARY_PATH
   echo PATH now $PATH
 #unset locally used variables


### PR DESCRIPTION
This PR fixes a problem if expected subdirs in the install area (bin,lib) are missing. Previously they prepended : to PATH or the LD_LIBRARY_PATH. That's fixed now - even an empty installation area will result in unchanged paths