### PR TITLE
use new cdb url

### DIFF
--- a/etc/sPHENIX_newcdb.json
+++ b/etc/sPHENIX_newcdb.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "nopayloaddb.apps.rcf.bnl.gov",
+  "base_url": "sphenix-cdb.apps.sdcc.bnl.gov",
   "api_res":  "/api/cdb_rest/",
   "write_dir": "/sphenix/cvmfscalib/sphnxpro/cdb/",
   "read_dir_list": ["/cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdb/", "/sphenix/cvmfscalib/sphnxpro/cdb/"],

--- a/etc/sPHENIX_newcdb_debug.json
+++ b/etc/sPHENIX_newcdb_debug.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "nopayloaddb.apps.rcf.bnl.gov",
+  "base_url": "sphenix-cdb.apps.sdcc.bnl.gov",
   "api_res":  "/api/cdb_rest/",
   "write_dir": "/sphenix/cvmfscalib/sphnxpro/cdb/",
   "read_dir_list": ["/cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdb/", "/sphenix/cvmfscalib/sphnxpro/cdb/"],


### PR DESCRIPTION
A stuck pod was the reason for the slowness using the new url last time. That's been fixed - this switches us again to the new url for the cdb